### PR TITLE
Fix script for use with Catalina (where "itunes" -> "Music")

### DIFF
--- a/spotify-ad
+++ b/spotify-ad
@@ -40,9 +40,9 @@ on run argv
                     tell application "Spotify"
                         if ":ad:" is in spotify url of current track then
                             set sound volume to 0
-                            Tell application "itunes" to play
+                            Tell application "Music" to play
                         else
-                            Tell application "itunes" to pause
+                            Tell application "Music" to pause
                             set sound volume to lastVolume 
                         end if
                     end tell
@@ -53,16 +53,16 @@ on run argv
                         if ":ad:" is in spotify url of current track and state is equal to "Music" then
                             set state to "Ad"
                             set sound volume to 0
-                            Tell application "itunes"  to play
+                            Tell application "Music"  to play
                             Tell application "Spotify" to play
                         else if state is equal to "Ad"
-                            Tell application "itunes" 
+                            Tell application "Music" 
                                 if get finish of current track -  player position is less than 1
                                     set state to "Music"
                                     Tell application "Spotify" to set sound volume to lastVolume
                                     Tell application "Spotify" to play
-                                    Tell application "itunes"  to next track
-                                    Tell application "itunes"  to pause
+                                    Tell application "Music"  to next track
+                                    Tell application "Music"  to pause
                                 else
                                     Tell application "Spotify" to if ":ad:" is not in spotify url of current track then pause
                                 end if


### PR DESCRIPTION
Apple killed itunes in favor of "Music" in Catalina. This update fixes the script to no longer refer to itunes.
https://www.howtogeek.com/443462/where-are-itunes-features-in-macos-catalina/

